### PR TITLE
fix: limit progressbar segments to 25

### DIFF
--- a/src/app/components/basic/ProgressBar.tsx
+++ b/src/app/components/basic/ProgressBar.tsx
@@ -1,13 +1,22 @@
 export const ProgressBar = ({ max, value }: { max: number; value: number }) => {
+  let maxValue = max;
+  let progressValue = value;
+
+  // Limit amount of segments to prevent overflow
+  if (max > 25) {
+    maxValue = 25;
+    progressValue = Math.round((value / max) * 25);
+  }
+
   return (
     <div className="border-accent-dark flex w-full gap-[2px] border-2 p-[2px]">
-      {Array.from({ length: value }).map((_, i) => (
+      {Array.from({ length: progressValue }).map((_, i) => (
         <span
           key={`filled-${i}`}
           className="bg-accent-dark inline-block h-[15px] min-w-1 flex-1"
         />
       ))}
-      {Array.from({ length: max - value }).map((_, i) => (
+      {Array.from({ length: maxValue - progressValue }).map((_, i) => (
         <span
           key={`empty-${i}`}
           className="inline-block h-[15px] min-w-1 flex-1"


### PR DESCRIPTION
- This should prevent overflow e.g. with big event quotas