### PR TITLE
feat: show payment info only on confirmed signup

### DIFF
--- a/locales/en.ts
+++ b/locales/en.ts
@@ -141,6 +141,7 @@ const en = {
   "product": "Product",
   "price": "Price",
   "public": "public",
+  "payment-info-message": "Payment is done according to separate instructions.",
 };
 
 type FiKey = keyof typeof fi;

--- a/locales/fi.ts
+++ b/locales/fi.ts
@@ -144,6 +144,7 @@ const fi = {
   "product": "Tuote",
   "price": "Hinta",
   "public": "julkinen",
+  "payment-info-message": "Maksaminen tapahtuu erillisten ohjeiden mukaisesti.",
 };
 
 type EnKey = keyof typeof en;

--- a/src/app/components/signup/PaymentInfo.tsx
+++ b/src/app/components/signup/PaymentInfo.tsx
@@ -57,6 +57,7 @@ export const PaymentInfo = ({
           </tbody>
         </table>
       </div>
+      <p className="font-pixel mt-4 text-base">{t("payment-info-message")}</p>
     </Window>
   );
 };


### PR DESCRIPTION
- All signup data is now reloaded after save to ensure consistent state