### PR TITLE
fix: update lexical styles

### DIFF
--- a/src/app/components/lexical/LexicalSerializer.tsx
+++ b/src/app/components/lexical/LexicalSerializer.tsx
@@ -53,6 +53,11 @@ export const LexicalSerializer: React.FC<{
       return <Tag className={className}>{children}</Tag>;
     },
 
+    paragraph: ({ node, nodesToJSX }) => {
+      const children = nodesToJSX({ nodes: node.children });
+      return <p className="my-3">{children}</p>;
+    },
+
     blocks: {
       eventGrid: ({
         node,


### PR DESCRIPTION
Ordered/unordered lists now have correct styles (closes #82):
<img width="203" height="190" alt="image" src="https://github.com/user-attachments/assets/65e6e487-f2ad-42a9-91f2-e9692940c246" />

And paragraphs have margins before/after:
<img width="799" height="521" alt="image" src="https://github.com/user-attachments/assets/e5d115b0-4699-482b-854e-cf8d45b06c49" />
