### PR TITLE
Change header colours for normal pages

### DIFF
--- a/src/app/[locale]/(with_layout)/[...path]/page.tsx
+++ b/src/app/[locale]/(with_layout)/[...path]/page.tsx
@@ -44,7 +44,7 @@ export default async function Page(props: Props) {
         text={page.title.replaceAll("&shy;", "\u00AD")}
         animated
         size="medium"
-        className="py-10 break-words hyphens-auto backdrop-blur-2xl"
+        className="py-10 wrap-break-word hyphens-auto backdrop-blur-2xl"
       />
       <main className="container mx-auto max-w-[90dvh] px-8 py-4 sm:max-w-4xl">
         {page.body &&

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -13,7 +13,7 @@ export default function Header({
 }) {
   return (
     <div
-      className={`${className} bg-accent-light text-header relative flex items-end justify-center`}
+      className={`${className} bg-juvu-blue-dark text-accent-light relative flex items-end justify-center`}
     >
       <Redaction text={text} size={size ?? "large"} animated={animated} />
     </div>

--- a/src/app/components/Redaction.tsx
+++ b/src/app/components/Redaction.tsx
@@ -49,7 +49,7 @@ export const Redaction = ({
         : "text-[clamp(3rem,13vw,6rem)]";
   return (
     <h1
-      className={`${sizeClass} ${redaction35.className} m-8 max-w-full text-center break-words hyphens-auto`}
+      className={`${sizeClass} ${redaction35.className} m-8 max-w-full text-center wrap-break-word hyphens-auto`}
     >
       {animated ? (
         text.split("").map((char, index) => {


### PR DESCRIPTION
Change normal page header colour to align with the frontpage and muistinnollaus page colours.
![Screenshot 2026-01-25 at 13 55 01](https://github.com/user-attachments/assets/b75b049a-5134-4b31-9ebe-efced400afc1)
