### PR TITLE
fix: table overflow on mobile chrome

### DIFF
--- a/src/app/components/m0/m0.tsx
+++ b/src/app/components/m0/m0.tsx
@@ -106,7 +106,7 @@ Proceed with Format (Y/N)? y";
               </Window>
               {config.showQuotaInfo && <QuotaWindow event={event} />}
             </div>
-            <div className="md:col-span-2 md:row-start-4 md:px-10">
+            <div className="overflow-x-auto md:col-span-2 md:row-start-4 md:px-10">
               <Window title={t("ilmomasiina.Ilmoittautuneet")}>
                 <SignUpList event={event} />
               </Window>


### PR DESCRIPTION
On small Chrome screens the layout was broken as the signups table was wider than the screen/window